### PR TITLE
Godoc cosmetics fixes

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -2,12 +2,12 @@ package linq
 
 // Aggregate applies an accumulator function over a sequence.
 //
-// Aggregate method makes it simple to perform a calculation over a sequence of values.
-// This method works by calling f() one time for each element in source
-// except the first one. Each time f() is called, Aggregate passes both
-// the element from the sequence and an aggregated value (as the first argument to f()).
-// The first element of source is used as the initial aggregate value.
-// The result of f() replaces the previous aggregated value.
+// Aggregate method makes it simple to perform a calculation over a sequence of
+// values. This method works by calling f() one time for each element in source
+// except the first one. Each time f() is called, Aggregate passes both the
+// element from the sequence and an aggregated value (as the first argument to
+// f()). The first element of source is used as the initial aggregate value. The
+// result of f() replaces the previous aggregated value.
 //
 // Aggregate returns the final result of f().
 func (q Query) Aggregate(
@@ -28,9 +28,9 @@ func (q Query) Aggregate(
 
 // AggregateT is the typed version of Aggregate.
 //
-// NOTE: Aggregate method has better performance than AggregateT
+//   - f is of type: func(TSource, TSource) TSource
 //
-// f is of type: func(TSource, TSource) TSource
+// NOTE: Aggregate has better performance than AggregateT.
 func (q Query) AggregateT(f interface{}) interface{} {
 
 	fGenericFunc, err := newGenericFunc(
@@ -48,14 +48,14 @@ func (q Query) AggregateT(f interface{}) interface{} {
 	return q.Aggregate(fFunc)
 }
 
-// AggregateWithSeed applies an accumulator function over a sequence.
-// The specified seed value is used as the initial accumulator value.
+// AggregateWithSeed applies an accumulator function over a sequence. The
+// specified seed value is used as the initial accumulator value.
 //
-// Aggregate method makes it simple to perform a calculation over a sequence of values.
-// This method works by calling f() one time for each element in source
-// except the first one. Each time f() is called, Aggregate passes both
-// the element from the sequence and an aggregated value (as the first argument to f()).
-// The value of the seed parameter is used as the initial aggregate value.
+// Aggregate method makes it simple to perform a calculation over a sequence of
+// values. This method works by calling f() one time for each element in source
+// except the first one. Each time f() is called, Aggregate passes both the
+// element from the sequence and an aggregated value (as the first argument to
+// f()). The value of the seed parameter is used as the initial aggregate value.
 // The result of f() replaces the previous aggregated value.
 //
 // Aggregate returns the final result of f().
@@ -76,9 +76,10 @@ func (q Query) AggregateWithSeed(
 
 // AggregateWithSeedT is the typed version of AggregateWithSeed.
 //
-// NOTE: AggregateWithSeed method has better performance than AggregateWithSeedT
+//   - f is of type "func(TAccumulate, TSource) TAccumulate"
 //
-// f is of a type "func(TAccumulate, TSource) TAccumulate"
+// NOTE: AggregateWithSeed has better performance than
+// AggregateWithSeedT.
 func (q Query) AggregateWithSeedT(seed interface{}, f interface{}) interface{} {
 	fGenericFunc, err := newGenericFunc(
 		"AggregateWithSeed", "f", f,
@@ -95,17 +96,19 @@ func (q Query) AggregateWithSeedT(seed interface{}, f interface{}) interface{} {
 	return q.AggregateWithSeed(seed, fFunc)
 }
 
-// AggregateWithSeedBy applies an accumulator function over a sequence.
-// The specified seed value is used as the initial accumulator value,
-// and the specified function is used to select the result value.
+// AggregateWithSeedBy applies an accumulator function over a sequence. The
+// specified seed value is used as the initial accumulator value, and the
+// specified function is used to select the result value.
 //
-// Aggregate method makes it simple to perform a calculation over a sequence of values.
-// This method works by calling f() one time for each element in source.
-// Each time func is called, Aggregate passes both the element from the sequence and an
-// aggregated value (as the first argument to func). The value of the seed parameter is used
-// as the initial aggregate value. The result of func replaces the previous aggregated value.
+// Aggregate method makes it simple to perform a calculation over a sequence of
+// values. This method works by calling f() one time for each element in source.
+// Each time func is called, Aggregate passes both the element from the sequence
+// and an aggregated value (as the first argument to func). The value of the
+// seed parameter is used as the initial aggregate value. The result of func
+// replaces the previous aggregated value.
 //
-// The final result of func is passed to resultSelector to obtain the final result of Aggregate.
+// The final result of func is passed to resultSelector to obtain the final
+// result of Aggregate.
 func (q Query) AggregateWithSeedBy(
 	seed interface{},
 	f func(interface{}, interface{}) interface{},
@@ -124,11 +127,11 @@ func (q Query) AggregateWithSeedBy(
 
 // AggregateWithSeedByT is the typed version of AggregateWithSeedBy.
 //
-// NOTE: AggregateWithSeedBy method has better performance than AggregateWithSeedByT
+//   - f is of type "func(TAccumulate, TSource) TAccumulate"
+//   - resultSelectorFn is of type "func(TAccumulate) TResult"
 //
-// f is of a type "func(TAccumulate, TSource) TAccumulate"
-//
-// resultSelectorFn is of type "func(TAccumulate) TResult"
+// NOTE: AggregateWithSeedBy has better performance than
+// AggregateWithSeedByT.
 func (q Query) AggregateWithSeedByT(seed interface{}, f interface{}, resultSelectorFn interface{}) interface{} {
 	fGenericFunc, err := newGenericFunc(
 		"AggregateWithSeedByT", "f", f,

--- a/compare.go
+++ b/compare.go
@@ -2,21 +2,21 @@ package linq
 
 type comparer func(interface{}, interface{}) int
 
-// Comparable is an interface that has to be implemented by a
-// custom collection elememts in order to work with linq.
+// Comparable is an interface that has to be implemented by a custom collection
+// elememts in order to work with linq.
 //
 // Example:
-//		func (f foo) CompareTo(c Comparable) int {
-//			a, b := f.f1, c.(foo).f1
+// 	func (f foo) CompareTo(c Comparable) int {
+// 		a, b := f.f1, c.(foo).f1
 //
-//			if a < b {
-//				return -1
-//			} else if a > b {
-//				return 1
-//			}
+// 		if a < b {
+// 			return -1
+// 		} else if a > b {
+// 			return 1
+// 		}
 //
-//			return 0
-//		}
+// 		return 0
+// 	}
 type Comparable interface {
 	CompareTo(Comparable) int
 }

--- a/concat.go
+++ b/concat.go
@@ -1,7 +1,7 @@
 package linq
 
-// Append inserts an item to the end of a collection,
-// so it becomes the last item.
+// Append inserts an item to the end of a collection, so it becomes the last
+// item.
 func (q Query) Append(item interface{}) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -28,8 +28,8 @@ func (q Query) Append(item interface{}) Query {
 // Concat concatenates two collections.
 //
 // The Concat method differs from the Union method because the Concat method
-// returns all the original elements in the input sequences.
-// The Union method returns only unique elements.
+// returns all the original elements in the input sequences. The Union method
+// returns only unique elements.
 func (q Query) Concat(q2 Query) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -53,8 +53,8 @@ func (q Query) Concat(q2 Query) Query {
 	}
 }
 
-// Prepend inserts an item to the beginning of a collection,
-// so it becomes the first item.
+// Prepend inserts an item to the beginning of a collection, so it becomes the
+// first item.
 func (q Query) Prepend(item interface{}) Query {
 	return Query{
 		Iterate: func() Iterator {

--- a/distinct.go
+++ b/distinct.go
@@ -1,7 +1,7 @@
 package linq
 
-// Distinct method returns distinct elements from a collection.
-// The result is an unordered collection that contains no duplicate values.
+// Distinct method returns distinct elements from a collection. The result is an
+// unordered collection that contains no duplicate values.
 func (q Query) Distinct() Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -22,11 +22,11 @@ func (q Query) Distinct() Query {
 	}
 }
 
-// Distinct method returns distinct elements from a collection.
-// The result is an ordered collection that contains no duplicate values.
+// Distinct method returns distinct elements from a collection. The result is an
+// ordered collection that contains no duplicate values.
 //
 // NOTE: Distinct method on OrderedQuery type has better performance than
-// Distinct method on Query type
+// Distinct method on Query type.
 func (oq OrderedQuery) Distinct() OrderedQuery {
 	return OrderedQuery{
 		orders: oq.orders,
@@ -76,9 +76,9 @@ func (q Query) DistinctBy(selector func(interface{}) interface{}) Query {
 
 // DistinctByT is the typed version of DistinctBy.
 //
-// NOTE: DistinctBy method has better performance than DistinctByT
+//   - selectorFn is of type "func(TSource) TSource".
 //
-// selectorFn is of type "func(TSource) TSource".
+// NOTE: DistinctBy has better performance than DistinctByT.
 func (q Query) DistinctByT(selectorFn interface{}) Query {
 	selectorFunc, ok := selectorFn.(func(interface{}) interface{})
 	if !ok {

--- a/except.go
+++ b/except.go
@@ -1,8 +1,7 @@
 package linq
 
-// Except produces the set difference of two sequences.
-// The set difference is the members of the first sequence
-// that don't appear in the second sequence.
+// Except produces the set difference of two sequences. The set difference is
+// the members of the first sequence that don't appear in the second sequence.
 func (q Query) Except(q2 Query) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -27,10 +26,9 @@ func (q Query) Except(q2 Query) Query {
 	}
 }
 
-// ExceptBy invokes a transform function on each element of a collection
-// and produces the set difference of two sequences.
-// The set difference is the members of the first sequence
-// that don't appear in the second sequence.
+// ExceptBy invokes a transform function on each element of a collection and
+// produces the set difference of two sequences. The set difference is the
+// members of the first sequence that don't appear in the second sequence.
 func (q Query) ExceptBy(
 	q2 Query, selector func(interface{}) interface{}) Query {
 	return Query{
@@ -60,9 +58,9 @@ func (q Query) ExceptBy(
 
 // ExceptByT is the typed version of ExceptBy.
 //
-// NOTE: ExceptBy method has better performance than ExceptByT
+//   - selectorFn is of type "func(TSource) TSource"
 //
-// selectorFn is of a type "func(TSource) TSource"
+// NOTE: ExceptBy has better performance than ExceptByT.
 func (q Query) ExceptByT(q2 Query, selectorFn interface{}) Query {
 	selectorGenericFunc, err := newGenericFunc(
 		"ExceptByT", "selectorFn", selectorFn,

--- a/from.go
+++ b/from.go
@@ -5,30 +5,30 @@ import "reflect"
 // Iterator is an alias for function to iterate over data.
 type Iterator func() (item interface{}, ok bool)
 
-// Query is the type returned from query functions.
-// It can be iterated manually as shown in the example.
+// Query is the type returned from query functions. It can be iterated manually
+// as shown in the example.
 type Query struct {
 	Iterate func() Iterator
 }
 
-// KeyValue is a type that is used to iterate over a map
-// (if query is created from a map). This type is also used by
-// ToMap() method to output result of a query into a map.
+// KeyValue is a type that is used to iterate over a map (if query is created
+// from a map). This type is also used by ToMap() method to output result of a
+// query into a map.
 type KeyValue struct {
 	Key   interface{}
 	Value interface{}
 }
 
-// Iterable is an interface that has to be implemented by a
-// custom collection in order to work with linq.
+// Iterable is an interface that has to be implemented by a custom collection in
+// order to work with linq.
 type Iterable interface {
 	Iterate() Iterator
 }
 
-// From initializes a linq query with passed slice, array or map
-// as the source. String, channel or struct implementing Iterable
-// interface can be used as an input. In this case From delegates it
-// to FromString, FromChannel and FromIterable internally.
+// From initializes a linq query with passed slice, array or map as the source.
+// String, channel or struct implementing Iterable interface can be used as an
+// input. In this case From delegates it to FromString, FromChannel and
+// FromIterable internally.
 func From(source interface{}) Query {
 	src := reflect.ValueOf(source)
 
@@ -84,8 +84,8 @@ func From(source interface{}) Query {
 	}
 }
 
-// FromChannel initializes a linq query with passed channel,
-// linq iterates over channel until it is closed.
+// FromChannel initializes a linq query with passed channel, linq iterates over
+// channel until it is closed.
 func FromChannel(source <-chan interface{}) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -97,8 +97,8 @@ func FromChannel(source <-chan interface{}) Query {
 	}
 }
 
-// FromString initializes a linq query with passed string,
-// linq iterates over runes of string.
+// FromString initializes a linq query with passed string, linq iterates over
+// runes of string.
 func FromString(source string) Query {
 	runes := []rune(source)
 	len := len(runes)
@@ -120,8 +120,8 @@ func FromString(source string) Query {
 	}
 }
 
-// FromIterable initializes a linq query with custom collection passed.
-// This collection has to implement Iterable interface, linq iterates over items,
+// FromIterable initializes a linq query with custom collection passed. This
+// collection has to implement Iterable interface, linq iterates over items,
 // that has to implement Comparable interface or be basic types.
 func FromIterable(source Iterable) Query {
 	return Query{

--- a/genericfunc.go
+++ b/genericfunc.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 )
 
-// genericType represents a any reflect.Type
+// genericType represents a any reflect.Type.
 type genericType int
 
 var genericTp = reflect.TypeOf(new(genericType)).Elem()
 
-// functionCache keeps genericFunc reflection objects in cache
+// functionCache keeps genericFunc reflection objects in cache.
 type functionCache struct {
 	MethodName string
 	ParamName  string
@@ -21,12 +21,12 @@ type functionCache struct {
 	TypesOut   []reflect.Type
 }
 
-// genericFunc is a type used to validate and call dynamic functions
+// genericFunc is a type used to validate and call dynamic functions.
 type genericFunc struct {
 	Cache *functionCache
 }
 
-// Call calls a dynamic function
+// Call calls a dynamic function.
 func (g *genericFunc) Call(params ...interface{}) interface{} {
 	paramsIn := make([]reflect.Value, len(params))
 	for i, param := range params {
@@ -68,7 +68,8 @@ func newGenericFunc(methodName, paramName string, fn interface{}, validateFunc f
 	return &genericFunc{Cache: cache}, nil
 }
 
-// simpleParamValidator creates a function to validate genericFunc based in the In and Out function parameters
+// simpleParamValidator creates a function to validate genericFunc based in the
+// In and Out function parameters.
 func simpleParamValidator(In []reflect.Type, Out []reflect.Type) func(cache *functionCache) error {
 	return func(cache *functionCache) error {
 		var isValid = func() bool {
@@ -102,7 +103,7 @@ func simpleParamValidator(In []reflect.Type, Out []reflect.Type) func(cache *fun
 	}
 }
 
-// newElemTypeSlice creates a slice of items elem types
+// newElemTypeSlice creates a slice of items elem types.
 func newElemTypeSlice(items ...interface{}) []reflect.Type {
 	typeList := make([]reflect.Type, len(items))
 	for i, item := range items {
@@ -114,7 +115,7 @@ func newElemTypeSlice(items ...interface{}) []reflect.Type {
 	return typeList
 }
 
-// formatFnSignature formats the func signature based in the parameters types
+// formatFnSignature formats the func signature based in the parameters types.
 func formatFnSignature(In []reflect.Type, Out []reflect.Type) string {
 	paramInNames := make([]string, len(In))
 	for i, typeIn := range In {

--- a/groupby.go
+++ b/groupby.go
@@ -6,9 +6,9 @@ type Group struct {
 	Group []interface{}
 }
 
-// GroupBy method groups the elements of a collection according
-// to a specified key selector function and projects the elements for each group
-// by using a specified function.
+// GroupBy method groups the elements of a collection according to a specified
+// key selector function and projects the elements for each group by using a
+// specified function.
 func (q Query) GroupBy(
 	keySelector func(interface{}) interface{},
 	elementSelector func(interface{}) interface{},
@@ -49,11 +49,10 @@ func (q Query) GroupBy(
 
 // GroupByT is the typed version of GroupBy.
 //
-// NOTE: GroupBy method has better performance than GroupByT
+//   - keySelectorFn is of type "func(TSource) TKey"
+//   - elementSelectorFn is of type "func(TSource) TElement"
 //
-// keySelectorFn is of a type "func(TSource) TKey"
-//
-// elementSelectorFn is of a type "func(TSource) TElement"
+// NOTE: GroupBy has better performance than GroupByT.
 func (q Query) GroupByT(keySelectorFn interface{}, elementSelectorFn interface{}) Query {
 	keySelectorGenericFunc, err := newGenericFunc(
 		"GroupByT", "keySelectorFn", keySelectorFn,

--- a/groupjoin.go
+++ b/groupjoin.go
@@ -5,17 +5,19 @@ import "reflect"
 // GroupJoin correlates the elements of two collections based on key equality,
 // and groups the results.
 //
-// This method produces hierarchical results, which means that elements from outer query
-// are paired with collections of matching elements from inner. GroupJoin enables you
-// to base your results on a whole set of matches for each element of outer query.
+// This method produces hierarchical results, which means that elements from
+// outer query are paired with collections of matching elements from inner.
+// GroupJoin enables you to base your results on a whole set of matches for each
+// element of outer query.
 //
 // The resultSelector function is called only one time for each outer element
-// together with a collection of all the inner elements that match the outer element.
-// This differs from the Join method, in which the result selector function is invoked
-// on pairs that contain one element from outer and one element from inner.
+// together with a collection of all the inner elements that match the outer
+// element. This differs from the Join method, in which the result selector
+// function is invoked on pairs that contain one element from outer and one
+// element from inner.
 //
-// GroupJoin preserves the order of the elements of outer, and for each element of outer,
-// the order of the matching elements from inner.
+// GroupJoin preserves the order of the elements of outer, and for each element
+// of outer, the order of the matching elements from inner.
 func (q Query) GroupJoin(
 	inner Query,
 	outerKeySelector func(interface{}) interface{},
@@ -53,15 +55,12 @@ func (q Query) GroupJoin(
 
 // GroupJoinT is the typed version of GroupJoin.
 //
-// NOTE: GroupJoin method has better performance than GroupJoinT
+//   - inner: The query to join to the outer query.
+//   - outerKeySelectorFn is of type "func(TOuter) TKey"
+//   - innerKeySelectorFn is of type "func(TInner) TKey"
+//   - resultSelectorFn: is of type "func(TOuter, inners []TInner) TResult"
 //
-// inner: The query to join to the outer query.
-//
-// outerKeySelectorFn is of a type "func(TOuter) TKey"
-//
-// innerKeySelectorFn is of a type "func(TInner) TKey"
-//
-// resultSelectorFn: is of a type "func(TOuter, inners []TInner) TResult"
+// NOTE: GroupJoin has better performance than GroupJoinT.
 func (q Query) GroupJoinT(inner Query, outerKeySelectorFn interface{}, innerKeySelectorFn interface{}, resultSelectorFn interface{}) Query {
 	outerKeySelectorGenericFunc, err := newGenericFunc(
 		"GroupJoinT", "outerKeySelectorFn", outerKeySelectorFn,

--- a/intersect.go
+++ b/intersect.go
@@ -2,8 +2,8 @@ package linq
 
 // Intersect produces the set intersection of the source collection and the
 // provided input collection. The intersection of two sets A and B is defined as
-// the set that contains all the elements of A that also appear in B,
-// but no other elements.
+// the set that contains all the elements of A that also appear in B, but no
+// other elements.
 func (q Query) Intersect(q2 Query) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -31,8 +31,8 @@ func (q Query) Intersect(q2 Query) Query {
 
 // IntersectBy produces the set intersection of the source collection and the
 // provided input collection. The intersection of two sets A and B is defined as
-// the set that contains all the elements of A that also appear in B,
-// but no other elements.
+// the set that contains all the elements of A that also appear in B, but no
+// other elements.
 //
 // IntersectBy invokes a transform function on each element of both collections.
 func (q Query) IntersectBy(
@@ -68,9 +68,9 @@ func (q Query) IntersectBy(
 
 // IntersectByT is the typed version of IntersectBy.
 //
-// NOTE: IntersectBy method has better performance than IntersectByT
+//   - selectorFn is of type "func(TSource) TSource"
 //
-// selectorFn is of a type "func(TSource) TSource"
+// NOTE: IntersectBy has better performance than IntersectByT.
 func (q Query) IntersectByT(q2 Query, selectorFn interface{}) Query {
 	selectorGenericFunc, err := newGenericFunc(
 		"IntersectByT", "selectorFn", selectorFn,

--- a/join.go
+++ b/join.go
@@ -2,14 +2,14 @@ package linq
 
 // Join correlates the elements of two collection based on matching keys.
 //
-// A join refers to the operation of correlating the elements of two sources
-// of information based on a common key. Join brings the two information sources
-// and the keys by which they are matched together in one method call.
-// This differs from the use of SelectMany, which requires more than one method call
+// A join refers to the operation of correlating the elements of two sources of
+// information based on a common key. Join brings the two information sources
+// and the keys by which they are matched together in one method call. This
+// differs from the use of SelectMany, which requires more than one method call
 // to perform the same operation.
 //
-// Join preserves the order of the elements of outer collection,
-// and for each of these elements, the order of the matching elements of inner.
+// Join preserves the order of the elements of outer collection, and for each of
+// these elements, the order of the matching elements of inner.
 func (q Query) Join(
 	inner Query,
 	outerKeySelector func(interface{}) interface{},
@@ -57,13 +57,11 @@ func (q Query) Join(
 
 // JoinT is the typed version of Join.
 //
-// NOTE: Join method has better performance than JoinT
+//   - outerKeySelectorFn is of type "func(TOuter) TKey"
+//   - innerKeySelectorFn is of type "func(TInner) TKey"
+//   - resultSelectorFn is of type "func(TOuter,TInner) TResult"
 //
-// outerKeySelectorFn is of a type "func(TOuter) TKey"
-//
-// innerKeySelectorFn is of a type "func(TInner) TKey"
-//
-// resultSelectorFn is of a type "func(TOuter,TInner) TResult"
+// NOTE: Join has better performance than JoinT.
 func (q Query) JoinT(inner Query,
 	outerKeySelectorFn interface{},
 	innerKeySelectorFn interface{},

--- a/orderby.go
+++ b/orderby.go
@@ -8,16 +8,16 @@ type order struct {
 	desc     bool
 }
 
-// OrderedQuery is the type returned from OrderBy, OrderByDescending
-// ThenBy and ThenByDescending functions.
+// OrderedQuery is the type returned from OrderBy, OrderByDescending ThenBy and
+// ThenByDescending functions.
 type OrderedQuery struct {
 	Query
 	original Query
 	orders   []order
 }
 
-// OrderBy sorts the elements of a collection in ascending order.
-// Elements are sorted according to a key.
+// OrderBy sorts the elements of a collection in ascending order. Elements are
+// sorted according to a key.
 func (q Query) OrderBy(
 	selector func(interface{}) interface{}) OrderedQuery {
 	return OrderedQuery{
@@ -45,9 +45,9 @@ func (q Query) OrderBy(
 
 // OrderByT is the typed version of OrderBy.
 //
-// NOTE: OrderBy method has better performance than OrderByT
+//   - selectorFn is of type "func(TSource) TKey"
 //
-// selectorFn is of a type "func(TSource) TKey"
+// NOTE: OrderBy has better performance than OrderByT.
 func (q Query) OrderByT(selectorFn interface{}) OrderedQuery {
 	selectorGenericFunc, err := newGenericFunc(
 		"OrderByT", "selectorFn", selectorFn,
@@ -92,10 +92,8 @@ func (q Query) OrderByDescending(
 }
 
 // OrderByDescendingT is the typed version of OrderByDescending.
-//
-// NOTE: OrderByDescending method has better performance than OrderByDescendingT
-//
-// selectorFn is of a type "func(TSource) TKey"
+//   - selectorFn is of type "func(TSource) TKey"
+// NOTE: OrderByDescending has better performance than OrderByDescendingT.
 func (q Query) OrderByDescendingT(selectorFn interface{}) OrderedQuery {
 	selectorGenericFunc, err := newGenericFunc(
 		"OrderByDescendingT", "selectorFn", selectorFn,
@@ -112,9 +110,9 @@ func (q Query) OrderByDescendingT(selectorFn interface{}) OrderedQuery {
 	return q.OrderByDescending(selectorFunc)
 }
 
-// ThenBy performs a subsequent ordering of the elements in a collection
-// in ascending order. This method enables you to specify multiple sort criteria
-// by applying any number of ThenBy or ThenByDescending methods.
+// ThenBy performs a subsequent ordering of the elements in a collection in
+// ascending order. This method enables you to specify multiple sort criteria by
+// applying any number of ThenBy or ThenByDescending methods.
 func (oq OrderedQuery) ThenBy(
 	selector func(interface{}) interface{}) OrderedQuery {
 	return OrderedQuery{
@@ -141,10 +139,8 @@ func (oq OrderedQuery) ThenBy(
 }
 
 // ThenByT is the typed version of ThenBy.
-//
-// NOTE: ThenBy method has better performance than ThenByT
-//
-// selectorFn is of a type "func(TSource) TKey"
+//   - selectorFn is of type "func(TSource) TKey"
+// NOTE: ThenBy has better performance than ThenByT.
 func (oq OrderedQuery) ThenByT(selectorFn interface{}) OrderedQuery {
 	selectorGenericFunc, err := newGenericFunc(
 		"ThenByT", "selectorFn", selectorFn,
@@ -161,9 +157,9 @@ func (oq OrderedQuery) ThenByT(selectorFn interface{}) OrderedQuery {
 	return oq.ThenBy(selectorFunc)
 }
 
-// ThenByDescending performs a subsequent ordering of the elements in a collection
-// in descending order. This method enables you to specify multiple sort criteria
-// by applying any number of ThenBy or ThenByDescending methods.
+// ThenByDescending performs a subsequent ordering of the elements in a
+// collection in descending order. This method enables you to specify multiple
+// sort criteria by applying any number of ThenBy or ThenByDescending methods.
 func (oq OrderedQuery) ThenByDescending(
 	selector func(interface{}) interface{}) OrderedQuery {
 	return OrderedQuery{
@@ -190,10 +186,8 @@ func (oq OrderedQuery) ThenByDescending(
 }
 
 // ThenByDescendingT is the typed version of ThenByDescending.
-//
-// NOTE: ThenByDescending method has better performance than ThenByDescendingT
-//
-// selectorFn is of a type "func(TSource) TKey"
+//   - selectorFn is of type "func(TSource) TKey"
+// NOTE: ThenByDescending has better performance than ThenByDescendingT.
 func (oq OrderedQuery) ThenByDescendingT(selectorFn interface{}) OrderedQuery {
 	selectorFunc, ok := selectorFn.(func(interface{}) interface{})
 	if !ok {
@@ -212,10 +206,11 @@ func (oq OrderedQuery) ThenByDescendingT(selectorFn interface{}) OrderedQuery {
 	return oq.ThenByDescending(selectorFunc)
 }
 
-// Sort returns a new query by sorting elements with provided less function
-// in ascending order. The comparer function should return true if the parameter i
-// is less than j. While this method is uglier than chaining OrderBy, OrderByDescending,
-// ThenBy and ThenByDescending methods, it's performance is much better.
+// Sort returns a new query by sorting elements with provided less function in
+// ascending order. The comparer function should return true if the parameter i
+// is less than j. While this method is uglier than chaining OrderBy,
+// OrderByDescending, ThenBy and ThenByDescending methods, it's performance is
+// much better.
 func (q Query) Sort(less func(i, j interface{}) bool) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -237,10 +232,8 @@ func (q Query) Sort(less func(i, j interface{}) bool) Query {
 }
 
 // SortT is the typed version of Sort.
-//
-// NOTE: Sort method has better performance than SortT
-//
-// lessFn is of a type "func(TSource,TSource) bool"
+//   - lessFn is of type "func(TSource,TSource) bool"
+// NOTE: Sort has better performance than SortT.
 func (q Query) SortT(lessFn interface{}) Query {
 	lessGenericFunc, err := newGenericFunc(
 		"SortT", "lessFn", lessFn,

--- a/result.go
+++ b/result.go
@@ -20,9 +20,9 @@ func (q Query) All(predicate func(interface{}) bool) bool {
 
 // AllT is the typed version of All.
 //
-// NOTE: All method has better performance than AllT
+//   - predicateFn is of type "func(TSource) bool"
 //
-// predicateFn is of a type "func(TSource) bool"
+// NOTE: All has better performance than AllT.
 func (q Query) AllT(predicateFn interface{}) bool {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -60,9 +60,9 @@ func (q Query) AnyWith(predicate func(interface{}) bool) bool {
 
 // AnyWithT is the typed version of AnyWith.
 //
-// NOTE: AnyWith method has better performance than AnyWithT
+//   - predicateFn is of type "func(TSource) bool"
 //
-// predicateFn is of a type "func(TSource) bool"
+// NOTE: AnyWith has better performance than AnyWithT.
 func (q Query) AnyWithT(predicateFn interface{}) bool {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -147,8 +147,8 @@ func (q Query) Count() (r int) {
 	return
 }
 
-// CountWith returns a number that represents how many elements
-// in the specified collection satisfy a condition.
+// CountWith returns a number that represents how many elements in the specified
+// collection satisfy a condition.
 func (q Query) CountWith(predicate func(interface{}) bool) (r int) {
 	next := q.Iterate()
 
@@ -163,9 +163,9 @@ func (q Query) CountWith(predicate func(interface{}) bool) (r int) {
 
 // CountWithT is the typed version of CountWith.
 //
-// NOTE: CountWith method has better performance than CountWithT
+//   - predicateFn is of type "func(TSource) bool"
 //
-// predicateFn is of a type "func(TSource) bool"
+// NOTE: CountWith has better performance than CountWithT.
 func (q Query) CountWithT(predicateFn interface{}) int {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -189,8 +189,8 @@ func (q Query) First() interface{} {
 	return item
 }
 
-// FirstWith returns the first element of a collection that satisfies
-// a specified condition.
+// FirstWith returns the first element of a collection that satisfies a
+// specified condition.
 func (q Query) FirstWith(predicate func(interface{}) bool) interface{} {
 	next := q.Iterate()
 
@@ -205,9 +205,9 @@ func (q Query) FirstWith(predicate func(interface{}) bool) interface{} {
 
 // FirstWithT is the typed version of FirstWith.
 //
-// NOTE: FirstWith method has better performance than FirstWithT
+//   - predicateFn is of type "func(TSource) bool"
 //
-// predicateFn is of a type "func(TSource) bool"
+// NOTE: FirstWith has better performance than FirstWithT.
 func (q Query) FirstWithT(predicateFn interface{}) interface{} {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -236,8 +236,8 @@ func (q Query) Last() (r interface{}) {
 	return
 }
 
-// LastWith returns the last element of a collection that satisfies
-// a specified condition.
+// LastWith returns the last element of a collection that satisfies a specified
+// condition.
 func (q Query) LastWith(predicate func(interface{}) bool) (r interface{}) {
 	next := q.Iterate()
 
@@ -252,9 +252,9 @@ func (q Query) LastWith(predicate func(interface{}) bool) (r interface{}) {
 
 // LastWithT is the typed version of LastWith.
 //
-// NOTE: LastWith method has better performance than LastWithT
+//   - predicateFn is of type "func(TSource) bool"
 //
-// predicateFn is of a type "func(TSource) bool"
+// NOTE: LastWith has better performance than LastWithT.
 func (q Query) LastWithT(predicateFn interface{}) interface{} {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -339,8 +339,8 @@ func (q Query) SequenceEqual(q2 Query) bool {
 	return !ok2
 }
 
-// Single returns the only element of a collection, and nil
-// if there is not exactly one element in the collection.
+// Single returns the only element of a collection, and nil if there is not
+// exactly one element in the collection.
 func (q Query) Single() interface{} {
 	next := q.Iterate()
 	item, ok := next()
@@ -356,8 +356,8 @@ func (q Query) Single() interface{} {
 	return item
 }
 
-// SingleWith returns the only element of a collection that satisfies
-// a specified condition, and nil if more than one such element exists.
+// SingleWith returns the only element of a collection that satisfies a
+// specified condition, and nil if more than one such element exists.
 func (q Query) SingleWith(predicate func(interface{}) bool) (r interface{}) {
 	next := q.Iterate()
 	found := false
@@ -378,9 +378,9 @@ func (q Query) SingleWith(predicate func(interface{}) bool) (r interface{}) {
 
 // SingleWithT is the typed version of SingleWith.
 //
-// NOTE: SingleWith method has better performance than SingleWithT
+//   - predicateFn is of type "func(TSource) bool"
 //
-// predicateFn is of a type "func(TSource) bool"
+// NOTE: SingleWith has better performance than SingleWithT.
 func (q Query) SingleWithT(predicateFn interface{}) interface{} {
 	predicateGenericFunc, err := newGenericFunc(
 		"SingleWithT", "predicateFn", predicateFn,
@@ -399,8 +399,8 @@ func (q Query) SingleWithT(predicateFn interface{}) interface{} {
 
 // SumInts computes the sum of a collection of numeric values.
 //
-// Values can be of any integer type: int, int8, int16, int32, int64.
-// The result is int64. Method returns zero if collection contains no elements.
+// Values can be of any integer type: int, int8, int16, int32, int64. The result
+// is int64. Method returns zero if collection contains no elements.
 func (q Query) SumInts() (r int64) {
 	next := q.Iterate()
 	item, ok := next()
@@ -420,8 +420,9 @@ func (q Query) SumInts() (r int64) {
 
 // SumUInts computes the sum of a collection of numeric values.
 //
-// Values can be of any unsigned integer type: uint, uint8, uint16, uint32, uint64.
-// The result is uint64. Method returns zero if collection contains no elements.
+// Values can be of any unsigned integer type: uint, uint8, uint16, uint32,
+// uint64. The result is uint64. Method returns zero if collection contains no
+// elements.
 func (q Query) SumUInts() (r uint64) {
 	next := q.Iterate()
 	item, ok := next()
@@ -460,8 +461,8 @@ func (q Query) SumFloats() (r float64) {
 	return
 }
 
-// ToChannel iterates over a collection and outputs each element
-// to a channel, then closes it.
+// ToChannel iterates over a collection and outputs each element to a channel,
+// then closes it.
 func (q Query) ToChannel(result chan<- interface{}) {
 	next := q.Iterate()
 
@@ -473,9 +474,9 @@ func (q Query) ToChannel(result chan<- interface{}) {
 }
 
 // ToMap iterates over a collection and populates result map with elements.
-// Collection elements have to be of KeyValue type to use this method.
-// To populate a map with elements of different type use ToMapBy method.
-// ToMap doesn't empty the result map before populating it.
+// Collection elements have to be of KeyValue type to use this method. To
+// populate a map with elements of different type use ToMapBy method. ToMap
+// doesn't empty the result map before populating it.
 func (q Query) ToMap(result interface{}) {
 	q.ToMapBy(
 		result,
@@ -487,10 +488,10 @@ func (q Query) ToMap(result interface{}) {
 		})
 }
 
-// ToMapBy iterates over a collection and populates the result map with elements.
-// Functions keySelector and valueSelector are executed for each element of the collection
-// to generate key and value for the map. Generated key and value types must be assignable
-// to the map's key and value types.
+// ToMapBy iterates over a collection and populates the result map with
+// elements. Functions keySelector and valueSelector are executed for each
+// element of the collection to generate key and value for the map. Generated
+// key and value types must be assignable to the map's key and value types.
 // ToMapBy doesn't empty the result map before populating it.
 func (q Query) ToMapBy(
 	result interface{},
@@ -513,11 +514,10 @@ func (q Query) ToMapBy(
 
 // ToMapByT is the typed version of ToMapBy.
 //
-// NOTE: ToMapBy method has better performance than ToMapByT
+//   - keySelectorFn is of type "func(TSource)TKey"
+//   - valueSelectorFn is of type "func(TSource)TValue"
 //
-// keySelectorFn is of a type "func(TSource)TKey"
-//
-// valueSelectorFn is of a type "func(TSource)TValue"
+// NOTE: ToMapBy has better performance than ToMapByT.
 func (q Query) ToMapByT(result interface{}, keySelectorFn interface{}, valueSelectorFn interface{}) {
 	keySelectorGenericFunc, err := newGenericFunc(
 		"ToMapByT", "keySelectorFn", keySelectorFn,

--- a/reverse.go
+++ b/reverse.go
@@ -2,9 +2,9 @@ package linq
 
 // Reverse inverts the order of the elements in a collection.
 //
-// Unlike OrderBy, this sorting method does not consider the actual values themselves
-// in determining the order. Rather, it just returns the elements in the reverse order
-// from which they are produced by the underlying source.
+// Unlike OrderBy, this sorting method does not consider the actual values
+// themselves in determining the order. Rather, it just returns the elements in
+// the reverse order from which they are produced by the underlying source.
 func (q Query) Reverse() Query {
 	return Query{
 		Iterate: func() Iterator {

--- a/select.go
+++ b/select.go
@@ -1,17 +1,16 @@
 package linq
 
-// Select projects each element of a collection into a new form.
-// Returns a query with the result of invoking the transform function
-// on each element of original source.
+// Select projects each element of a collection into a new form. Returns a query
+// with the result of invoking the transform function on each element of
+// original source.
 //
-// This projection method requires the transform function, selector,
-// to produce one value for each value in the source collection.
-// If selector returns a value that is itself a collection,
-// it is up to the consumer to traverse the subcollections manually.
-// In such a situation, it might be better for your query to return a single
-// coalesced collection of values. To achieve this, use the SelectMany method
-// instead of Select. Although SelectMany works similarly to Select,
-// it differs in that the transform function returns a collection
+// This projection method requires the transform function, selector, to produce
+// one value for each value in the source collection. If selector returns a
+// value that is itself a collection, it is up to the consumer to traverse the
+// subcollections manually. In such a situation, it might be better for your
+// query to return a single coalesced collection of values. To achieve this, use
+// the SelectMany method instead of Select. Although SelectMany works similarly
+// to Select, it differs in that the transform function returns a collection
 // that is then expanded by SelectMany before it is returned.
 func (q Query) Select(selector func(interface{}) interface{}) Query {
 	return Query{
@@ -32,10 +31,8 @@ func (q Query) Select(selector func(interface{}) interface{}) Query {
 }
 
 // SelectT is the typed version of Select.
-//
-// NOTE: Select method has better performance than SelectT
-//
-// selectorFn is of a type "func(TSource)TResult"
+//   - selectorFn is of type "func(TSource)TResult"
+// NOTE: Select has better performance than SelectT.
 func (q Query) SelectT(selectorFn interface{}) Query {
 
 	selectGenericFunc, err := newGenericFunc(
@@ -53,24 +50,24 @@ func (q Query) SelectT(selectorFn interface{}) Query {
 	return q.Select(selectorFunc)
 }
 
-// SelectIndexed projects each element of a collection into a new form
-// by incorporating the element's index. Returns a query with the result
-// of invoking the transform function on each element of original source.
+// SelectIndexed projects each element of a collection into a new form by
+// incorporating the element's index. Returns a query with the result of
+// invoking the transform function on each element of original source.
 //
-// The first argument to selector represents the zero-based index of that element
-// in the source collection. This can be useful if the elements are in a known order
-// and you want to do something with an element at a particular index,
-// for example. It can also be useful if you want to retrieve the index of one
-// or more elements. The second argument to selector represents the element to process.
+// The first argument to selector represents the zero-based index of that
+// element in the source collection. This can be useful if the elements are in a
+// known order and you want to do something with an element at a particular
+// index, for example. It can also be useful if you want to retrieve the index
+// of one or more elements. The second argument to selector represents the
+// element to process.
 //
-// This projection method requires the transform function, selector,
-// to produce one value for each value in the source collection.
-// If selector returns a value that is itself a collection,
-// it is up to the consumer to traverse the subcollections manually.
-// In such a situation, it might be better for your query to return a single
-// coalesced collection of values. To achieve this, use the SelectMany method
-// instead of Select. Although SelectMany works similarly to Select,
-// it differs in that the transform function returns a collection
+// This projection method requires the transform function, selector, to produce
+// one value for each value in the source collection. If selector returns a
+// value that is itself a collection, it is up to the consumer to traverse the
+// subcollections manually. In such a situation, it might be better for your
+// query to return a single coalesced collection of values. To achieve this, use
+// the SelectMany method instead of Select. Although SelectMany works similarly
+// to Select, it differs in that the transform function returns a collection
 // that is then expanded by SelectMany before it is returned.
 func (q Query) SelectIndexed(selector func(int, interface{}) interface{}) Query {
 	return Query{
@@ -93,10 +90,8 @@ func (q Query) SelectIndexed(selector func(int, interface{}) interface{}) Query 
 }
 
 // SelectIndexedT is the typed version of SelectIndexed.
-//
-// NOTE: SelectIndexed method has better performance than SelectIndexedT
-//
-// selectorFn is of a type "func(int,TSource)TResult"
+//   - selectorFn is of type "func(int,TSource)TResult"
+// NOTE: SelectIndexed has better performance than SelectIndexedT.
 func (q Query) SelectIndexedT(selectorFn interface{}) Query {
 	selectGenericFunc, err := newGenericFunc(
 		"SelectIndexedT", "selectorFn", selectorFn,

--- a/selectmany.go
+++ b/selectmany.go
@@ -34,9 +34,9 @@ func (q Query) SelectMany(selector func(interface{}) Query) Query {
 
 // SelectManyT is the typed version of SelectMany.
 //
-// NOTE: SelectMany method has better performance than SelectManyT
+//   - selectorFn is of type "func(TSource)Query"
 //
-// selectorFn is of a type "func(TSource)Query"
+// NOTE: SelectMany has better performance than SelectManyT.
 func (q Query) SelectManyT(selectorFn interface{}) Query {
 
 	selectManyGenericFunc, err := newGenericFunc(
@@ -54,14 +54,15 @@ func (q Query) SelectManyT(selectorFn interface{}) Query {
 
 }
 
-// SelectManyIndexed projects each element of a collection to a Query, iterates and
-// flattens the resulting collection into one collection.
+// SelectManyIndexed projects each element of a collection to a Query, iterates
+// and flattens the resulting collection into one collection.
 //
-// The first argument to selector represents the zero-based index of that element
-// in the source collection. This can be useful if the elements are in a known order
-// and you want to do something with an element at a particular index, for example.
-// It can also be useful if you want to retrieve the index of one or more elements.
-// The second argument to selector represents the element to process.
+// The first argument to selector represents the zero-based index of that
+// element in the source collection. This can be useful if the elements are in a
+// known order and you want to do something with an element at a particular
+// index, for example. It can also be useful if you want to retrieve the index
+// of one or more elements. The second argument to selector represents the
+// element to process.
 func (q Query) SelectManyIndexed(selector func(int, interface{}) Query) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -96,9 +97,9 @@ func (q Query) SelectManyIndexed(selector func(int, interface{}) Query) Query {
 
 // SelectManyIndexedT is the typed version of SelectManyIndexed.
 //
-// NOTE: SelectManyIndexed method has better performance than SelectManyIndexedT
+//   - selectorFn is of type "func(int,TSource)Query"
 //
-// selectorFn is of a type "func(int,TSource)Query"
+// NOTE: SelectManyIndexed has better performance than SelectManyIndexedT.
 func (q Query) SelectManyIndexedT(selectorFn interface{}) Query {
 
 	selectManyIndexedGenericFunc, err := newGenericFunc(
@@ -117,8 +118,8 @@ func (q Query) SelectManyIndexedT(selectorFn interface{}) Query {
 }
 
 // SelectManyBy projects each element of a collection to a Query, iterates and
-// flattens the resulting collection into one collection, and invokes
-// a result selector function on each element therein.
+// flattens the resulting collection into one collection, and invokes a result
+// selector function on each element therein.
 func (q Query) SelectManyBy(
 	selector func(interface{}) Query,
 	resultSelector func(interface{}, interface{}) interface{},
@@ -156,11 +157,10 @@ func (q Query) SelectManyBy(
 
 // SelectManyByT is the typed version of SelectManyBy.
 //
-// NOTE: SelectManyBy method has better performance than SelectManyByT
+//   - selectorFn is of type "func(TSource)Query"
+//   - resultSelectorFn is of type "func(TSource,TCollection)TResult"
 //
-// selectorFn is of a type "func(TSource)Query"
-//
-// resultSelectorFn is of a type "func(TSource,TCollection)TResult"
+// NOTE: SelectManyBy has better performance than SelectManyByT.
 func (q Query) SelectManyByT(selectorFn interface{}, resultSelectorFn interface{}) Query {
 
 	selectorGenericFunc, err := newGenericFunc(
@@ -190,11 +190,10 @@ func (q Query) SelectManyByT(selectorFn interface{}, resultSelectorFn interface{
 	return q.SelectManyBy(selectorFunc, resultSelectorFunc)
 }
 
-// SelectManyByIndexed projects each element of a collection to a Query, iterates and
-// flattens the resulting collection into one collection, and invokes
-// a result selector function on each element therein.
-// The index of each source element is used in the intermediate projected form
-// of that element.
+// SelectManyByIndexed projects each element of a collection to a Query,
+// iterates and flattens the resulting collection into one collection, and
+// invokes a result selector function on each element therein. The index of each
+// source element is used in the intermediate projected form of that element.
 func (q Query) SelectManyByIndexed(selector func(int, interface{}) Query,
 	resultSelector func(interface{}, interface{}) interface{}) Query {
 
@@ -232,11 +231,11 @@ func (q Query) SelectManyByIndexed(selector func(int, interface{}) Query,
 
 // SelectManyByIndexedT is the typed version of SelectManyByIndexed.
 //
-// NOTE: SelectManyByIndexed method has better performance than SelectManyByIndexedT
+//   - selectorFn is of type "func(int,TSource)Query"
+//   - resultSelectorFn is of type "func(TSource,TCollection)TResult"
 //
-// selectorFn is of a type "func(int,TSource)Query"
-//
-// resultSelectorFn is of a type "func(TSource,TCollection)TResult"
+// NOTE: SelectManyByIndexed has better performance than
+// SelectManyByIndexedT.
 func (q Query) SelectManyByIndexedT(selectorFn interface{}, resultSelectorFn interface{}) Query {
 	selectorGenericFunc, err := newGenericFunc(
 		"SelectManyByIndexedT", "selectorFn", selectorFn,

--- a/skip.go
+++ b/skip.go
@@ -1,7 +1,7 @@
 package linq
 
-// Skip bypasses a specified number of elements in a collection
-// and then returns the remaining elements.
+// Skip bypasses a specified number of elements in a collection and then returns
+// the remaining elements.
 func (q Query) Skip(count int) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -22,13 +22,13 @@ func (q Query) Skip(count int) Query {
 	}
 }
 
-// SkipWhile bypasses elements in a collection as long as a specified condition is true
-// and then returns the remaining elements.
+// SkipWhile bypasses elements in a collection as long as a specified condition
+// is true and then returns the remaining elements.
 //
-// This method tests each element by using predicate and skips the element
-// if the result is true. After the predicate function returns false for an element,
-// that element and the remaining elements in source are returned
-// and there are no more invocations of predicate.
+// This method tests each element by using predicate and skips the element if
+// the result is true. After the predicate function returns false for an
+// element, that element and the remaining elements in source are returned and
+// there are no more invocations of predicate.
 func (q Query) SkipWhile(predicate func(interface{}) bool) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -56,9 +56,9 @@ func (q Query) SkipWhile(predicate func(interface{}) bool) Query {
 
 // SkipWhileT is the typed version of SkipWhile.
 //
-// NOTE: SkipWhile method has better performance than SkipWhileT
+//   - predicateFn is of type "func(TSource)bool"
 //
-// predicateFn is of a type "func(TSource)bool"
+// NOTE: SkipWhile has better performance than SkipWhileT.
 func (q Query) SkipWhileT(predicateFn interface{}) Query {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -76,14 +76,14 @@ func (q Query) SkipWhileT(predicateFn interface{}) Query {
 	return q.SkipWhile(predicateFunc)
 }
 
-// SkipWhileIndexed bypasses elements in a collection as long as a specified condition
-// is true and then returns the remaining elements. The element's index is used
-// in the logic of the predicate function.
+// SkipWhileIndexed bypasses elements in a collection as long as a specified
+// condition is true and then returns the remaining elements. The element's
+// index is used in the logic of the predicate function.
 //
-// This method tests each element by using predicate and skips the element
-// if the result is true. After the predicate function returns false for an element,
-// that element and the remaining elements in source are returned
-// and there are no more invocations of predicate.
+// This method tests each element by using predicate and skips the element if
+// the result is true. After the predicate function returns false for an
+// element, that element and the remaining elements in source are returned and
+// there are no more invocations of predicate.
 func (q Query) SkipWhileIndexed(predicate func(int, interface{}) bool) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -114,9 +114,9 @@ func (q Query) SkipWhileIndexed(predicate func(int, interface{}) bool) Query {
 
 // SkipWhileIndexedT is the typed version of SkipWhileIndexed.
 //
-// NOTE: SkipWhileIndexed method has better performance than SkipWhileIndexedT
+//   - predicateFn is of type "func(int,TSource)bool"
 //
-// predicateFn is of a type "func(int,TSource)bool"
+// NOTE: SkipWhileIndexed has better performance than SkipWhileIndexedT.
 func (q Query) SkipWhileIndexedT(predicateFn interface{}) Query {
 	predicateGenericFunc, err := newGenericFunc(
 		"SkipWhileIndexedT", "predicateFn", predicateFn,

--- a/take.go
+++ b/take.go
@@ -1,6 +1,7 @@
 package linq
 
-// Take returns a specified number of contiguous elements from the start of a collection.
+// Take returns a specified number of contiguous elements from the start of a
+// collection.
 func (q Query) Take(count int) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -19,8 +20,8 @@ func (q Query) Take(count int) Query {
 	}
 }
 
-// TakeWhile returns elements from a collection as long as a specified condition is true,
-// and then skips the remaining elements.
+// TakeWhile returns elements from a collection as long as a specified condition
+// is true, and then skips the remaining elements.
 func (q Query) TakeWhile(predicate func(interface{}) bool) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -51,9 +52,9 @@ func (q Query) TakeWhile(predicate func(interface{}) bool) Query {
 
 // TakeWhileT is the typed version of TakeWhile.
 //
-// NOTE: TakeWhile method has better performance than TakeWhileT
+//   - predicateFn is of type "func(TSource)bool"
 //
-// predicateFn is of a type "func(TSource)bool"
+// NOTE: TakeWhile has better performance than TakeWhileT.
 func (q Query) TakeWhileT(predicateFn interface{}) Query {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -71,10 +72,11 @@ func (q Query) TakeWhileT(predicateFn interface{}) Query {
 	return q.TakeWhile(predicateFunc)
 }
 
-// TakeWhileIndexed returns elements from a collection as long as a specified condition
-// is true. The element's index is used in the logic of the predicate function.
-// The first argument of predicate represents the zero-based index of the element
-// within collection. The second argument represents the element to test.
+// TakeWhileIndexed returns elements from a collection as long as a specified
+// condition is true. The element's index is used in the logic of the predicate
+// function. The first argument of predicate represents the zero-based index of
+// the element within collection. The second argument represents the element to
+// test.
 func (q Query) TakeWhileIndexed(predicate func(int, interface{}) bool) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -107,9 +109,9 @@ func (q Query) TakeWhileIndexed(predicate func(int, interface{}) bool) Query {
 
 // TakeWhileIndexedT is the typed version of TakeWhileIndexed.
 //
-// NOTE: TakeWhileIndexed method has better performance than TakeWhileIndexedT
+//   - predicateFn is of type "func(int,TSource)bool"
 //
-// predicateFn is of a type "func(int,TSource)bool"
+// NOTE: TakeWhileIndexed has better performance than TakeWhileIndexedT.
 func (q Query) TakeWhileIndexedT(predicateFn interface{}) Query {
 	whereFunc, err := newGenericFunc(
 		"TakeWhileIndexedT", "predicateFn", predicateFn,

--- a/union.go
+++ b/union.go
@@ -2,10 +2,9 @@ package linq
 
 // Union produces the set union of two collections.
 //
-// This method excludes duplicates from the return set.
-// This is different behavior to the Concat method,
-// which returns all the elements in the input collection
-// including duplicates.
+// This method excludes duplicates from the return set. This is different
+// behavior to the Concat method, which returns all the elements in the input
+// collection including duplicates.
 func (q Query) Union(q2 Query) Query {
 	return Query{
 		Iterate: func() Iterator {

--- a/where.go
+++ b/where.go
@@ -21,9 +21,9 @@ func (q Query) Where(predicate func(interface{}) bool) Query {
 
 // WhereT is the typed version of Where.
 //
-// NOTE: Where method has better performance than WhereT
+//   - predicateFn is of type "func(TSource)bool"
 //
-// predicateFn is of a type "func(TSource)bool"
+// NOTE: Where has better performance than WhereT.
 func (q Query) WhereT(predicateFn interface{}) Query {
 
 	predicateGenericFunc, err := newGenericFunc(
@@ -41,11 +41,11 @@ func (q Query) WhereT(predicateFn interface{}) Query {
 	return q.Where(predicateFunc)
 }
 
-// WhereIndexed filters a collection of values based on a predicate.
-// Each element's index is used in the logic of the predicate function.
+// WhereIndexed filters a collection of values based on a predicate. Each
+// element's index is used in the logic of the predicate function.
 //
-// The first argument represents the zero-based index of the element within collection.
-// The second argument of predicate represents the element to test.
+// The first argument represents the zero-based index of the element within
+// collection. The second argument of predicate represents the element to test.
 func (q Query) WhereIndexed(predicate func(int, interface{}) bool) Query {
 	return Query{
 		Iterate: func() Iterator {
@@ -69,9 +69,9 @@ func (q Query) WhereIndexed(predicate func(int, interface{}) bool) Query {
 
 // WhereIndexedT is the typed version of WhereIndexed.
 //
-// NOTE: WhereIndexed method has better performance than WhereIndexedT
+//   - predicateFn is of type "func(int,TSource)bool"
 //
-// predicateFn is of a type "func(int,TSource)bool"
+// NOTE: WhereIndexed has better performance than WhereIndexedT.
 func (q Query) WhereIndexedT(predicateFn interface{}) Query {
 	predicateGenericFunc, err := newGenericFunc(
 		"WhereIndexedT", "predicateFn", predicateFn,

--- a/zip.go
+++ b/zip.go
@@ -1,15 +1,15 @@
 package linq
 
-// Zip applies a specified function to the corresponding elements
-// of two collections, producing a collection of the results.
+// Zip applies a specified function to the corresponding elements of two
+// collections, producing a collection of the results.
 //
 // The method steps through the two input collections, applying function
-// resultSelector to corresponding elements of the two collections.
-// The method returns a collection of the values that are returned by resultSelector.
-// If the input collections do not have the same number of elements,
-// the method combines elements until it reaches the end of one of the collections.
-// For example, if one collection has three elements and the other one has four,
-// the result collection has only three elements.
+// resultSelector to corresponding elements of the two collections. The method
+// returns a collection of the values that are returned by resultSelector. If
+// the input collections do not have the same number of elements, the method
+// combines elements until it reaches the end of one of the collections. For
+// example, if one collection has three elements and the other one has four, the
+// result collection has only three elements.
 func (q Query) Zip(
 	q2 Query,
 	resultSelector func(interface{}, interface{}) interface{},
@@ -36,9 +36,9 @@ func (q Query) Zip(
 
 // ZipT is the typed version of Zip.
 //
-// NOTE: Zip method has better performance than ZipT
+//   - resultSelectorFn is of type "func(TFirst,TSecond)TResult"
 //
-// resultSelectorFn is of a type "func(TFirst,TSecond)TResult"
+// NOTE: Zip has better performance than ZipT.
 func (q Query) ZipT(q2 Query, resultSelectorFn interface{}) Query {
 	resultSelectorFunc, ok := resultSelectorFn.(func(interface{}, interface{}) interface{})
 	if !ok {


### PR DESCRIPTION
- Collected ".. is of a type" in bullet lists
- Added trailing periods (`.`) in godocs
- Wrapped godoc comments to a consistent length (vscode-rewrap)
- Moved NOTE blocks to the end.
