### PR TITLE
Fixed ZipT to reuse regular method

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -40,35 +40,17 @@ func (q Query) Zip(
 //
 // NOTE: Zip has better performance than ZipT.
 func (q Query) ZipT(q2 Query, resultSelectorFn interface{}) Query {
-	resultSelectorFunc, ok := resultSelectorFn.(func(interface{}, interface{}) interface{})
-	if !ok {
-		resultSelectorGenericFunc, err := newGenericFunc(
-			"ZipT", "resultSelectorFn", resultSelectorFn,
-			simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(genericType))),
-		)
-		if err != nil {
-			panic(err)
-		}
-
-		resultSelectorFunc = func(item1 interface{}, item2 interface{}) interface{} {
-			return resultSelectorGenericFunc.Call(item1, item2)
-		}
+	resultSelectorGenericFunc, err := newGenericFunc(
+		"ZipT", "resultSelectorFn", resultSelectorFn,
+		simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(genericType))),
+	)
+	if err != nil {
+		panic(err)
 	}
-	return Query{
-		Iterate: func() Iterator {
-			next1 := q.Iterate()
-			next2 := q2.Iterate()
 
-			return func() (item interface{}, ok bool) {
-				item1, ok1 := next1()
-				item2, ok2 := next2()
-
-				if ok1 && ok2 {
-					return resultSelectorFunc(item1, item2), true
-				}
-
-				return nil, false
-			}
-		},
+	resultSelectorFunc := func(item1 interface{}, item2 interface{}) interface{} {
+		return resultSelectorGenericFunc.Call(item1, item2)
 	}
+
+	return q.Zip(q2, resultSelectorFunc)
 }


### PR DESCRIPTION
Applied the same generic functions pattern to reuse regular method
instead a “reimplementation”.