### PR TITLE
ToSlice alternative: AddRange

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful language integrated query (LINQ) library for Go.
     $ go get github.com/ahmetalpbalkan/go-linq
 
 We recommend using a dependency manager (e.g. [govendor][govendor] or
-[godep][godep]) to maintain a local copy of this package in your projcet.
+[godep][godep]) to maintain a local copy of this package in your project.
 
 [govendor]: https://github.com/kardianos/govendor
 [godep]: https://github.com/tools/godep/


### PR DESCRIPTION
@ahmetalpbalkan The idea here is to offer an alternative to people that are currently using ToSlice method to append the result slice. The .Net Framework offers the AddRange method (I personally don’t like this name, we need to find a better one) that implements this idea.