### PR TITLE
Standardize line breaks on method signatures

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -10,8 +10,7 @@ package linq
 // result of f() replaces the previous aggregated value.
 //
 // Aggregate returns the final result of f().
-func (q Query) Aggregate(
-	f func(interface{}, interface{}) interface{}) interface{} {
+func (q Query) Aggregate(f func(interface{}, interface{}) interface{}) interface{} {
 	next := q.Iterate()
 
 	result, any := next()
@@ -32,7 +31,6 @@ func (q Query) Aggregate(
 //
 // NOTE: Aggregate has better performance than AggregateT.
 func (q Query) AggregateT(f interface{}) interface{} {
-
 	fGenericFunc, err := newGenericFunc(
 		"AggregateT", "f", f,
 		simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(genericType))),
@@ -59,10 +57,8 @@ func (q Query) AggregateT(f interface{}) interface{} {
 // The result of f() replaces the previous aggregated value.
 //
 // Aggregate returns the final result of f().
-func (q Query) AggregateWithSeed(
-	seed interface{},
-	f func(interface{}, interface{}) interface{},
-) interface{} {
+func (q Query) AggregateWithSeed(seed interface{},
+	f func(interface{}, interface{}) interface{}) interface{} {
 
 	next := q.Iterate()
 	result := seed
@@ -80,7 +76,8 @@ func (q Query) AggregateWithSeed(
 //
 // NOTE: AggregateWithSeed has better performance than
 // AggregateWithSeedT.
-func (q Query) AggregateWithSeedT(seed interface{}, f interface{}) interface{} {
+func (q Query) AggregateWithSeedT(seed interface{},
+	f interface{}) interface{} {
 	fGenericFunc, err := newGenericFunc(
 		"AggregateWithSeed", "f", f,
 		simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(genericType))),
@@ -109,11 +106,9 @@ func (q Query) AggregateWithSeedT(seed interface{}, f interface{}) interface{} {
 //
 // The final result of func is passed to resultSelector to obtain the final
 // result of Aggregate.
-func (q Query) AggregateWithSeedBy(
-	seed interface{},
+func (q Query) AggregateWithSeedBy(seed interface{},
 	f func(interface{}, interface{}) interface{},
-	resultSelector func(interface{}) interface{},
-) interface{} {
+	resultSelector func(interface{}) interface{}) interface{} {
 
 	next := q.Iterate()
 	result := seed
@@ -132,7 +127,9 @@ func (q Query) AggregateWithSeedBy(
 //
 // NOTE: AggregateWithSeedBy has better performance than
 // AggregateWithSeedByT.
-func (q Query) AggregateWithSeedByT(seed interface{}, f interface{}, resultSelectorFn interface{}) interface{} {
+func (q Query) AggregateWithSeedByT(seed interface{},
+	f interface{},
+	resultSelectorFn interface{}) interface{} {
 	fGenericFunc, err := newGenericFunc(
 		"AggregateWithSeedByT", "f", f,
 		simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(genericType))),

--- a/doc.go
+++ b/doc.go
@@ -1,8 +1,6 @@
-// Package linq provides methods for querying and manipulating
-// slices, arrays, maps, strings, channels and collections.
+// Package linq provides methods for querying and manipulating slices, arrays,
+// maps, strings, channels and collections.
 //
-//
-// Authors: Alexander Kalankhodzhaev (kalan), Ahmet Alp Balkan, Cleiton Marques Souza
-//
-//
+// Authors: Alexander Kalankhodzhaev (kalan), Ahmet Alp Balkan, Cleiton Marques
+// Souza.
 package linq

--- a/except.go
+++ b/except.go
@@ -29,8 +29,8 @@ func (q Query) Except(q2 Query) Query {
 // ExceptBy invokes a transform function on each element of a collection and
 // produces the set difference of two sequences. The set difference is the
 // members of the first sequence that don't appear in the second sequence.
-func (q Query) ExceptBy(
-	q2 Query, selector func(interface{}) interface{}) Query {
+func (q Query) ExceptBy(q2 Query,
+	selector func(interface{}) interface{}) Query {
 	return Query{
 		Iterate: func() Iterator {
 			next := q.Iterate()
@@ -61,7 +61,8 @@ func (q Query) ExceptBy(
 //   - selectorFn is of type "func(TSource) TSource"
 //
 // NOTE: ExceptBy has better performance than ExceptByT.
-func (q Query) ExceptByT(q2 Query, selectorFn interface{}) Query {
+func (q Query) ExceptByT(q2 Query,
+	selectorFn interface{}) Query {
 	selectorGenericFunc, err := newGenericFunc(
 		"ExceptByT", "selectorFn", selectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),

--- a/groupby.go
+++ b/groupby.go
@@ -9,11 +9,8 @@ type Group struct {
 // GroupBy method groups the elements of a collection according to a specified
 // key selector function and projects the elements for each group by using a
 // specified function.
-func (q Query) GroupBy(
-	keySelector func(interface{}) interface{},
-	elementSelector func(interface{}) interface{},
-) Query {
-
+func (q Query) GroupBy(keySelector func(interface{}) interface{},
+	elementSelector func(interface{}) interface{}) Query {
 	return Query{
 		func() Iterator {
 			next := q.Iterate()
@@ -53,7 +50,8 @@ func (q Query) GroupBy(
 //   - elementSelectorFn is of type "func(TSource) TElement"
 //
 // NOTE: GroupBy has better performance than GroupByT.
-func (q Query) GroupByT(keySelectorFn interface{}, elementSelectorFn interface{}) Query {
+func (q Query) GroupByT(keySelectorFn interface{},
+	elementSelectorFn interface{}) Query {
 	keySelectorGenericFunc, err := newGenericFunc(
 		"GroupByT", "keySelectorFn", keySelectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),

--- a/groupjoin.go
+++ b/groupjoin.go
@@ -18,12 +18,10 @@ import "reflect"
 //
 // GroupJoin preserves the order of the elements of outer, and for each element
 // of outer, the order of the matching elements from inner.
-func (q Query) GroupJoin(
-	inner Query,
+func (q Query) GroupJoin(inner Query,
 	outerKeySelector func(interface{}) interface{},
 	innerKeySelector func(interface{}) interface{},
-	resultSelector func(outer interface{}, inners []interface{}) interface{},
-) Query {
+	resultSelector func(outer interface{}, inners []interface{}) interface{}) Query {
 
 	return Query{
 		Iterate: func() Iterator {
@@ -61,7 +59,10 @@ func (q Query) GroupJoin(
 //   - resultSelectorFn: is of type "func(TOuter, inners []TInner) TResult"
 //
 // NOTE: GroupJoin has better performance than GroupJoinT.
-func (q Query) GroupJoinT(inner Query, outerKeySelectorFn interface{}, innerKeySelectorFn interface{}, resultSelectorFn interface{}) Query {
+func (q Query) GroupJoinT(inner Query,
+	outerKeySelectorFn interface{},
+	innerKeySelectorFn interface{},
+	resultSelectorFn interface{}) Query {
 	outerKeySelectorGenericFunc, err := newGenericFunc(
 		"GroupJoinT", "outerKeySelectorFn", outerKeySelectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),

--- a/intersect.go
+++ b/intersect.go
@@ -35,10 +35,8 @@ func (q Query) Intersect(q2 Query) Query {
 // other elements.
 //
 // IntersectBy invokes a transform function on each element of both collections.
-func (q Query) IntersectBy(
-	q2 Query,
-	selector func(interface{}) interface{},
-) Query {
+func (q Query) IntersectBy(q2 Query,
+	selector func(interface{}) interface{}) Query {
 
 	return Query{
 		Iterate: func() Iterator {
@@ -71,7 +69,8 @@ func (q Query) IntersectBy(
 //   - selectorFn is of type "func(TSource) TSource"
 //
 // NOTE: IntersectBy has better performance than IntersectByT.
-func (q Query) IntersectByT(q2 Query, selectorFn interface{}) Query {
+func (q Query) IntersectByT(q2 Query,
+	selectorFn interface{}) Query {
 	selectorGenericFunc, err := newGenericFunc(
 		"IntersectByT", "selectorFn", selectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),

--- a/join.go
+++ b/join.go
@@ -10,12 +10,10 @@ package linq
 //
 // Join preserves the order of the elements of outer collection, and for each of
 // these elements, the order of the matching elements of inner.
-func (q Query) Join(
-	inner Query,
+func (q Query) Join(inner Query,
 	outerKeySelector func(interface{}) interface{},
 	innerKeySelector func(interface{}) interface{},
-	resultSelector func(outer interface{}, inner interface{}) interface{},
-) Query {
+	resultSelector func(outer interface{}, inner interface{}) interface{}) Query {
 
 	return Query{
 		Iterate: func() Iterator {
@@ -65,8 +63,7 @@ func (q Query) Join(
 func (q Query) JoinT(inner Query,
 	outerKeySelectorFn interface{},
 	innerKeySelectorFn interface{},
-	resultSelectorFn interface{},
-) Query {
+	resultSelectorFn interface{}) Query {
 	outerKeySelectorGenericFunc, err := newGenericFunc(
 		"JoinT", "outerKeySelectorFn", outerKeySelectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),

--- a/orderby.go
+++ b/orderby.go
@@ -18,8 +18,7 @@ type OrderedQuery struct {
 
 // OrderBy sorts the elements of a collection in ascending order. Elements are
 // sorted according to a key.
-func (q Query) OrderBy(
-	selector func(interface{}) interface{}) OrderedQuery {
+func (q Query) OrderBy(selector func(interface{}) interface{}) OrderedQuery {
 	return OrderedQuery{
 		orders:   []order{{selector: selector}},
 		original: q,
@@ -66,8 +65,7 @@ func (q Query) OrderByT(selectorFn interface{}) OrderedQuery {
 
 // OrderByDescending sorts the elements of a collection in descending order.
 // Elements are sorted according to a key.
-func (q Query) OrderByDescending(
-	selector func(interface{}) interface{}) OrderedQuery {
+func (q Query) OrderByDescending(selector func(interface{}) interface{}) OrderedQuery {
 	return OrderedQuery{
 		orders:   []order{{selector: selector, desc: true}},
 		original: q,
@@ -160,8 +158,7 @@ func (oq OrderedQuery) ThenByT(selectorFn interface{}) OrderedQuery {
 // ThenByDescending performs a subsequent ordering of the elements in a
 // collection in descending order. This method enables you to specify multiple
 // sort criteria by applying any number of ThenBy or ThenByDescending methods.
-func (oq OrderedQuery) ThenByDescending(
-	selector func(interface{}) interface{}) OrderedQuery {
+func (oq OrderedQuery) ThenByDescending(selector func(interface{}) interface{}) OrderedQuery {
 	return OrderedQuery{
 		orders:   append(oq.orders, order{selector: selector, desc: true}),
 		original: oq.original,

--- a/result.go
+++ b/result.go
@@ -493,11 +493,9 @@ func (q Query) ToMap(result interface{}) {
 // element of the collection to generate key and value for the map. Generated
 // key and value types must be assignable to the map's key and value types.
 // ToMapBy doesn't empty the result map before populating it.
-func (q Query) ToMapBy(
-	result interface{},
+func (q Query) ToMapBy(result interface{},
 	keySelector func(interface{}) interface{},
-	valueSelector func(interface{}) interface{},
-) {
+	valueSelector func(interface{}) interface{}) {
 	res := reflect.ValueOf(result)
 	m := reflect.Indirect(res)
 	next := q.Iterate()
@@ -518,7 +516,8 @@ func (q Query) ToMapBy(
 //   - valueSelectorFn is of type "func(TSource)TValue"
 //
 // NOTE: ToMapBy has better performance than ToMapByT.
-func (q Query) ToMapByT(result interface{}, keySelectorFn interface{}, valueSelectorFn interface{}) {
+func (q Query) ToMapByT(result interface{},
+	keySelectorFn interface{}, valueSelectorFn interface{}) {
 	keySelectorGenericFunc, err := newGenericFunc(
 		"ToMapByT", "keySelectorFn", keySelectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),

--- a/selectmany.go
+++ b/selectmany.go
@@ -120,10 +120,8 @@ func (q Query) SelectManyIndexedT(selectorFn interface{}) Query {
 // SelectManyBy projects each element of a collection to a Query, iterates and
 // flattens the resulting collection into one collection, and invokes a result
 // selector function on each element therein.
-func (q Query) SelectManyBy(
-	selector func(interface{}) Query,
-	resultSelector func(interface{}, interface{}) interface{},
-) Query {
+func (q Query) SelectManyBy(selector func(interface{}) Query,
+	resultSelector func(interface{}, interface{}) interface{}) Query {
 
 	return Query{
 		Iterate: func() Iterator {
@@ -161,7 +159,8 @@ func (q Query) SelectManyBy(
 //   - resultSelectorFn is of type "func(TSource,TCollection)TResult"
 //
 // NOTE: SelectManyBy has better performance than SelectManyByT.
-func (q Query) SelectManyByT(selectorFn interface{}, resultSelectorFn interface{}) Query {
+func (q Query) SelectManyByT(selectorFn interface{},
+	resultSelectorFn interface{}) Query {
 
 	selectorGenericFunc, err := newGenericFunc(
 		"SelectManyByT", "selectorFn", selectorFn,
@@ -236,7 +235,8 @@ func (q Query) SelectManyByIndexed(selector func(int, interface{}) Query,
 //
 // NOTE: SelectManyByIndexed has better performance than
 // SelectManyByIndexedT.
-func (q Query) SelectManyByIndexedT(selectorFn interface{}, resultSelectorFn interface{}) Query {
+func (q Query) SelectManyByIndexedT(selectorFn interface{},
+	resultSelectorFn interface{}) Query {
 	selectorGenericFunc, err := newGenericFunc(
 		"SelectManyByIndexedT", "selectorFn", selectorFn,
 		simpleParamValidator(newElemTypeSlice(new(int), new(genericType)), newElemTypeSlice(new(Query))),

--- a/zip.go
+++ b/zip.go
@@ -10,10 +10,8 @@ package linq
 // combines elements until it reaches the end of one of the collections. For
 // example, if one collection has three elements and the other one has four, the
 // result collection has only three elements.
-func (q Query) Zip(
-	q2 Query,
-	resultSelector func(interface{}, interface{}) interface{},
-) Query {
+func (q Query) Zip(q2 Query,
+	resultSelector func(interface{}, interface{}) interface{}) Query {
 
 	return Query{
 		Iterate: func() Iterator {
@@ -39,7 +37,8 @@ func (q Query) Zip(
 //   - resultSelectorFn is of type "func(TFirst,TSecond)TResult"
 //
 // NOTE: Zip has better performance than ZipT.
-func (q Query) ZipT(q2 Query, resultSelectorFn interface{}) Query {
+func (q Query) ZipT(q2 Query,
+	resultSelectorFn interface{}) Query {
 	resultSelectorGenericFunc, err := newGenericFunc(
 		"ZipT", "resultSelectorFn", resultSelectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(genericType))),


### PR DESCRIPTION
I am standardizing the method signatures on long method names or
methods that accept predicateFns for prettier "go doc" or "godoc"
output based on following rules:

1. first parameter on the same line as method name
2. rest of the parameters are each on a new line
3. return type is at the same line as the last parameter

Here is the `go doc Query` output for reference:

```go
func From(source interface{}) Query
func FromChannel(source <-chan interface{}) Query
func FromIterable(source Iterable) Query
func FromString(source string) Query
func Range(start, count int) Query
func Repeat(value interface{}, count int) Query
func (q Query) Aggregate(f func(interface{}, interface{}) interface{}) interface{}
func (q Query) AggregateT(f interface{}) interface{}
func (q Query) AggregateWithSeed(seed interface{},
	f func(interface{}, interface{}) interface{}) interface{}
func (q Query) AggregateWithSeedBy(seed interface{},
	f func(interface{}, interface{}) interface{},
	resultSelector func(interface{}) interface{}) interface{}
func (q Query) AggregateWithSeedByT(seed interface{},
	f interface{},
	resultSelectorFn interface{}) interface{}
func (q Query) AggregateWithSeedT(seed interface{},
	f interface{}) interface{}
func (q Query) All(predicate func(interface{}) bool) bool
func (q Query) AllT(predicateFn interface{}) bool
func (q Query) Any() bool
func (q Query) AnyWith(predicate func(interface{}) bool) bool
func (q Query) AnyWithT(predicateFn interface{}) bool
func (q Query) Append(item interface{}) Query
func (q Query) Average() (r float64)
func (q Query) Concat(q2 Query) Query
func (q Query) Contains(value interface{}) bool
func (q Query) Count() (r int)
func (q Query) CountWith(predicate func(interface{}) bool) (r int)
func (q Query) CountWithT(predicateFn interface{}) int
func (q Query) Distinct() Query
func (q Query) DistinctBy(selector func(interface{}) interface{}) Query
func (q Query) DistinctByT(selectorFn interface{}) Query
func (q Query) Except(q2 Query) Query
func (q Query) ExceptBy(q2 Query,
	selector func(interface{}) interface{}) Query
func (q Query) ExceptByT(q2 Query,
	selectorFn interface{}) Query
func (q Query) First() interface{}
func (q Query) FirstWith(predicate func(interface{}) bool) interface{}
func (q Query) FirstWithT(predicateFn interface{}) interface{}
func (q Query) GroupBy(keySelector func(interface{}) interface{},
	elementSelector func(interface{}) interface{}) Query
func (q Query) GroupByT(keySelectorFn interface{},
	elementSelectorFn interface{}) Query
func (q Query) GroupJoin(inner Query,
	outerKeySelector func(interface{}) interface{},
	innerKeySelector func(interface{}) interface{},
	resultSelector func(outer interface{}, inners []interface{}) interface{}) Query
func (q Query) GroupJoinT(inner Query,
	outerKeySelectorFn interface{},
	innerKeySelectorFn interface{},
	resultSelectorFn interface{}) Query
func (q Query) Intersect(q2 Query) Query
func (q Query) IntersectBy(q2 Query,
	selector func(interface{}) interface{}) Query
func (q Query) IntersectByT(q2 Query,
	selectorFn interface{}) Query
func (q Query) Join(inner Query,
	outerKeySelector func(interface{}) interface{},
	innerKeySelector func(interface{}) interface{},
	resultSelector func(outer interface{}, inner interface{}) interface{}) Query
func (q Query) JoinT(inner Query,
	outerKeySelectorFn interface{},
	innerKeySelectorFn interface{},
	resultSelectorFn interface{}) Query
func (q Query) Last() (r interface{})
func (q Query) LastWith(predicate func(interface{}) bool) (r interface{})
func (q Query) LastWithT(predicateFn interface{}) interface{}
func (q Query) Max() (r interface{})
func (q Query) Min() (r interface{})
func (q Query) OrderBy(selector func(interface{}) interface{}) OrderedQuery
func (q Query) OrderByDescending(selector func(interface{}) interface{}) OrderedQuery
func (q Query) OrderByDescendingT(selectorFn interface{}) OrderedQuery
func (q Query) OrderByT(selectorFn interface{}) OrderedQuery
func (q Query) Prepend(item interface{}) Query
func (q Query) Results() (r []interface{})
func (q Query) Reverse() Query
func (q Query) Select(selector func(interface{}) interface{}) Query
func (q Query) SelectIndexed(selector func(int, interface{}) interface{}) Query
func (q Query) SelectIndexedT(selectorFn interface{}) Query
func (q Query) SelectMany(selector func(interface{}) Query) Query
func (q Query) SelectManyBy(selector func(interface{}) Query,
	resultSelector func(interface{}, interface{}) interface{}) Query
func (q Query) SelectManyByIndexed(selector func(int, interface{}) Query,
	resultSelector func(interface{}, interface{}) interface{}) Query
func (q Query) SelectManyByIndexedT(selectorFn interface{},
	resultSelectorFn interface{}) Query
func (q Query) SelectManyByT(selectorFn interface{},
	resultSelectorFn interface{}) Query
func (q Query) SelectManyIndexed(selector func(int, interface{}) Query) Query
func (q Query) SelectManyIndexedT(selectorFn interface{}) Query
func (q Query) SelectManyT(selectorFn interface{}) Query
func (q Query) SelectT(selectorFn interface{}) Query
func (q Query) SequenceEqual(q2 Query) bool
func (q Query) Single() interface{}
func (q Query) SingleWith(predicate func(interface{}) bool) (r interface{})
func (q Query) SingleWithT(predicateFn interface{}) interface{}
func (q Query) Skip(count int) Query
func (q Query) SkipWhile(predicate func(interface{}) bool) Query
func (q Query) SkipWhileIndexed(predicate func(int, interface{}) bool) Query
func (q Query) SkipWhileIndexedT(predicateFn interface{}) Query
func (q Query) SkipWhileT(predicateFn interface{}) Query
func (q Query) Sort(less func(i, j interface{}) bool) Query
func (q Query) SortT(lessFn interface{}) Query
func (q Query) SumFloats() (r float64)
func (q Query) SumInts() (r int64)
func (q Query) SumUInts() (r uint64)
func (q Query) Take(count int) Query
func (q Query) TakeWhile(predicate func(interface{}) bool) Query
func (q Query) TakeWhileIndexed(predicate func(int, interface{}) bool) Query
func (q Query) TakeWhileIndexedT(predicateFn interface{}) Query
func (q Query) TakeWhileT(predicateFn interface{}) Query
func (q Query) ToChannel(result chan<- interface{})
func (q Query) ToMap(result interface{})
func (q Query) ToMapBy(result interface{},
	keySelector func(interface{}) interface{},
	valueSelector func(interface{}) interface{})
func (q Query) ToMapByT(result interface{},
	keySelectorFn interface{}, valueSelectorFn interface{})
func (q Query) ToSlice(v interface{})
func (q Query) Union(q2 Query) Query
func (q Query) Where(predicate func(interface{}) bool) Query
func (q Query) WhereIndexed(predicate func(int, interface{}) bool) Query
func (q Query) WhereIndexedT(predicateFn interface{}) Query
func (q Query) WhereT(predicateFn interface{}) Query
func (q Query) Zip(q2 Query,
	resultSelector func(interface{}, interface{}) interface{}) Query
func (q Query) ZipT(q2 Query,
	resultSelectorFn interface{}) Query
```

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>