### PR TITLE
Add check for breaking API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - go get -u github.com/golang/lint/golint
+  - go get -u github.com/bradleyfalzon/apicompat/cmd/apicompat
 
 script:
   - go vet -x ./...
   - golint ./...
   - go test -v  ./...
   - go test -covermode=count -coverprofile=profile.cov
+  - test -z "$(apicompat -before ${TRAVIS_COMMIT_RANGE%...*} -after ${TRAVIS_COMMIT_RANGE#*...} ./... | tee /dev/stderr)"
 
 after_script:
   - goveralls -coverprofile=profile.cov -service=travis-ci


### PR DESCRIPTION
This should be able to detect breaking API changes in pull requests. Adding this in case we accidentally break things somehow.

When the breaking changes are by design, we must ignore the failing CI.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>