### PR TITLE
travis: check gofmt, capture errors from golint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_install:
 
 script:
   - go vet -x ./...
-  - golint ./...
+  - test -z "$(golint ./...)"
+  - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
   - go test -v  ./...
   - go test -covermode=count -coverprofile=profile.cov
 


### PR DESCRIPTION
golint does not exit with code!=0 on errors, so travis build
will continue with success, therefore using "test -z".

Adding gofmt check.