### PR TITLE
Fix typo, remove trailing newline from examples

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -3,7 +3,7 @@ package linq
 type comparer func(interface{}, interface{}) int
 
 // Comparable is an interface that has to be implemented by a custom collection
-// elememts in order to work with linq.
+// elements in order to work with linq.
 //
 // Example:
 // 	func (f foo) CompareTo(c Comparable) int {

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,6 @@ func ExampleKeyValue() {
 	m[10] = true
 
 	fmt.Println(From(m).Results())
-
 	// Output:
 	// [{10 true}]
 }
@@ -26,7 +25,6 @@ func ExampleKeyValue_second() {
 		ToMap(&m)
 
 	fmt.Println(m)
-
 	// Output:
 	// map[10:true]
 }
@@ -87,7 +85,6 @@ func ExampleQuery() {
 	for item, ok := next(); ok; item, ok = next() {
 		fmt.Println(item)
 	}
-
 	// Output:
 	// 1
 	// 2
@@ -110,7 +107,6 @@ func ExampleQuery_Aggregate() {
 		)
 
 	fmt.Println(longestName)
-
 	// Output:
 	// passionfruit
 }
@@ -207,7 +203,6 @@ func ExampleOrderedQuery_DistinctBy() {
 	for _, product := range noduplicates {
 		fmt.Printf("%s %d\n", product.Name, product.Code)
 	}
-
 	// Output:
 	// apple 9
 	// lemon 12
@@ -234,7 +229,6 @@ func ExampleOrderedQuery_ThenBy() {
 	for _, fruit := range query {
 		fmt.Println(fruit)
 	}
-
 	// Output:
 	// apple
 	// grape
@@ -271,7 +265,6 @@ func ExampleQuery_All() {
 		)
 
 	fmt.Printf("All pet names start with 'B'? %t", allStartWithB)
-
 	// Output:
 	//
 	//  All pet names start with 'B'? false
@@ -285,7 +278,6 @@ func ExampleQuery_Any() {
 	hasElements := From(numbers).Any()
 
 	fmt.Printf("Are there any element in the list? %t", hasElements)
-
 	// Output:
 	// Are there any element in the list? true
 }
@@ -315,7 +307,6 @@ func ExampleQuery_AnyWith() {
 		)
 
 	fmt.Printf("Are there any unvaccinated animals over age one? %t", unvaccinated)
-
 	// Output:
 	//
 	// Are there any unvaccinated animals over age one? true
@@ -331,7 +322,6 @@ func ExampleQuery_Append() {
 	last := q.Last()
 
 	fmt.Println(last)
-
 	// Output:
 	// 5
 }
@@ -343,7 +333,6 @@ func ExampleQuery_Average() {
 	average := From(grades).Average()
 
 	fmt.Println(average)
-
 	// Output:
 	// 77.6
 }
@@ -355,7 +344,6 @@ func ExampleQuery_Count() {
 	numberOfFruits := From(fruits).Count()
 
 	fmt.Println(numberOfFruits)
-
 	// Output:
 	// 6
 }
@@ -368,7 +356,6 @@ func ExampleQuery_Contains() {
 	has5 := From(slice).Contains(5)
 
 	fmt.Printf("Does the slice contains 5? %t", has5)
-
 	// Output:
 	// Does the slice contains 5? true
 }
@@ -384,7 +371,6 @@ func ExampleQuery_CountWith() {
 		)
 
 	fmt.Println(evenCount)
-
 	// Output:
 	// 6
 }
@@ -400,7 +386,6 @@ func ExampleQuery_Distinct() {
 		ToSlice(&distinctAges)
 
 	fmt.Println(distinctAges)
-
 	// Output:
 	// [21 46 55 17]
 }
@@ -431,7 +416,6 @@ func ExampleQuery_DistinctBy() {
 	for _, product := range noduplicates {
 		fmt.Printf("%s %d\n", product.Name, product.Code)
 	}
-
 	// Output:
 	// orange 4
 	// apple 9
@@ -454,7 +438,6 @@ func ExampleQuery_Except() {
 	for _, number := range onlyInFirstSet {
 		fmt.Println(number)
 	}
-
 	// Output:
 	//2
 	//2.1
@@ -495,7 +478,6 @@ func ExampleQuery_ExceptBy() {
 	for _, product := range except {
 		fmt.Printf("%s %d\n", product.Name, product.Code)
 	}
-
 	// Output:
 	// orange 4
 	// lemon 12
@@ -510,7 +492,6 @@ func ExampleQuery_First() {
 	first := From(numbers).First()
 
 	fmt.Println(first)
-
 	// Output:
 	// 9
 
@@ -527,7 +508,6 @@ func ExampleQuery_FirstWith() {
 		)
 
 	fmt.Println(first)
-
 	// Output:
 	// 92
 
@@ -547,7 +527,6 @@ func ExampleQuery_Intersect() {
 	for _, id := range both {
 		fmt.Println(id)
 	}
-
 	// Output:
 	// 26
 	// 30
@@ -582,7 +561,6 @@ func ExampleQuery_IntersectBy() {
 	for _, p := range duplicates {
 		fmt.Println(p.Name, "", p.Code)
 	}
-
 	// Output:
 	// apple  9
 
@@ -704,7 +682,6 @@ func ExampleQuery_Concat() {
 		Concat(From([]int{4, 5, 6}))
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [1 2 3 4 5 6]
 }
@@ -719,7 +696,6 @@ func ExampleQuery_GroupBy() {
 	fmt.Println(q.OrderBy(func(i interface{}) interface{} {
 		return i.(Group).Key
 	}).Results())
-
 	// Output:
 	// [{0 [2 4 6 8]} {1 [1 3 5 7 9]}]
 }
@@ -745,7 +721,6 @@ func ExampleQuery_GroupJoin() {
 		)
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [{a [apple apricot]} {b [banana]} {c [cherry clementine]}]
 }
@@ -771,7 +746,6 @@ func ExampleQuery_Join() {
 		)
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [{5 apple} {6 banana} {6 cherry} {7 apricot} {10 clementine}]
 }
@@ -788,7 +762,6 @@ func ExampleQuery_OrderBy() {
 		)
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [10 8 6 4 2 9 7 5 3 1]
 }
@@ -802,7 +775,6 @@ func ExampleQuery_Prepend() {
 	first := q.First()
 
 	fmt.Println(first)
-
 	// Output:
 	// 1
 }
@@ -818,7 +790,6 @@ func ExampleQuery_Reverse() {
 		ToSlice(&output)
 
 	fmt.Println(string(output))
-
 	// Output:
 	// elppa
 }
@@ -848,7 +819,6 @@ func ExampleQuery_SelectMany() {
 		)
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [1 2 3 4 5 6 7]
 }
@@ -917,7 +887,6 @@ func ExampleQuery_SelectManyByIndexed() {
 	for _, result := range results {
 		fmt.Println(result)
 	}
-
 	// Output:
 	// Pet: 0 - Daisy, Owner: Hedlund, Magnus
 	// Pet: 1 - Barley, Owner: Adams, Terry
@@ -972,7 +941,6 @@ func ExampleQuery_SelectManyIndexed() {
 	for _, result := range results {
 		fmt.Println(result)
 	}
-
 	// Output:
 	// File:[1] - file1.log => line: 1 - INFO: 2013/11/05 18:11:01 main.go:44: Special Information
 	// File:[1] - file1.log => line: 2 - WARNING: 2013/11/05 18:11:01 main.go:45: There is something you need to know about
@@ -1023,7 +991,6 @@ func ExampleQuery_SelectManyBy() {
 	for _, result := range results {
 		fmt.Println(result)
 	}
-
 	// Output:
 	// Owner: Hedlund, Magnus, Pet: Daisy
 	// Owner: Adams, Terry, Pet: Barley
@@ -1056,7 +1023,6 @@ func ExampleQuery_SequenceEqual() {
 	equal := From(pets1).SequenceEqual(From(pets2))
 
 	fmt.Printf("Are the lists equals? %t", equal)
-
 	// Output:
 	// Are the lists equals? true
 }
@@ -1172,7 +1138,6 @@ func ExampleQuery_SumFloats() {
 	sum := From(numbers).SumFloats()
 
 	fmt.Printf("The sum of the numbers is %f.", sum)
-
 	// Output:
 	// The sum of the numbers is 635.130000.
 
@@ -1186,7 +1151,6 @@ func ExampleQuery_SumInts() {
 	sum := From(numbers).SumInts()
 
 	fmt.Printf("The sum of the numbers is %d.", sum)
-
 	// Output:
 	// The sum of the numbers is 633.
 
@@ -1200,7 +1164,6 @@ func ExampleQuery_SumUInts() {
 	sum := From(numbers).SumUInts()
 
 	fmt.Printf("The sum of the numbers is %d.", sum)
-
 	// Output:
 	// The sum of the numbers is 633.
 
@@ -1220,7 +1183,6 @@ func ExampleQuery_Take() {
 		ToSlice(&topThreeGrades)
 
 	fmt.Printf("The top three grades are: %v", topThreeGrades)
-
 	// Output:
 	// The top three grades are: [98 92 85]
 
@@ -1239,7 +1201,6 @@ func ExampleQuery_TakeWhile() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [apple banana mango]
 }
@@ -1260,7 +1221,6 @@ func ExampleQuery_TakeWhileIndexed() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [apple passionfruit banana mango orange blueberry]
 }
@@ -1277,7 +1237,6 @@ func ExampleQuery_ToChannel() {
 	for i := range c {
 		fmt.Println(i)
 	}
-
 	// Output:
 	// 10
 	// 10
@@ -1308,7 +1267,6 @@ func ExampleQuery_ToMap() {
 	fmt.Println(map1[4])
 	fmt.Println(map1[9])
 	fmt.Println(map1[12])
-
 	// Output:
 	// orange
 	// apple
@@ -1332,7 +1290,6 @@ func ExampleQuery_ToMapBy() {
 		)
 
 	fmt.Println(result)
-
 	// Output:
 	// map[1:true]
 }
@@ -1343,7 +1300,6 @@ func ExampleQuery_ToSlice() {
 	Range(1, 10).ToSlice(&result)
 
 	fmt.Println(result)
-
 	// Output:
 	// [1 2 3 4 5 6 7 8 9 10]
 }
@@ -1354,7 +1310,6 @@ func ExampleQuery_Union() {
 	q := Range(1, 10).Union(Range(6, 10))
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
 }
@@ -1372,7 +1327,6 @@ func ExampleQuery_Where() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [passionfruit blueberry strawberry]
 }
@@ -1390,7 +1344,6 @@ func ExampleQuery_WhereIndexed() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [0 15 40]
 }
@@ -1407,7 +1360,6 @@ func ExampleQuery_Zip() {
 		)
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [[1 one] [2 two] [3 three]]
 }
@@ -1493,7 +1445,6 @@ func ExampleQuery_AggregateT() {
 	)
 
 	fmt.Println(reversed)
-
 	// Output:
 	// dog lazy the over jumps fox brown quick the
 }
@@ -1515,7 +1466,6 @@ func ExampleQuery_AggregateWithSeedT() {
 		)
 
 	fmt.Printf("The fruit with the longest name is %s.", longestName)
-
 	// Output:
 	// The fruit with the longest name is passionfruit.
 
@@ -1578,7 +1528,6 @@ func ExampleQuery_AllT() {
 	for _, student := range approvedStudents {
 		fmt.Println(student.Name)
 	}
-
 	// Output:
 	// Hugo
 	// Michael
@@ -1616,7 +1565,6 @@ func ExampleQuery_AnyWithT() {
 	for _, student := range studentsWithAnyMarkLt70 {
 		fmt.Println(student.Name)
 	}
-
 	// Output:
 	// Rick
 	// Fadi
@@ -1675,7 +1623,6 @@ func ExampleQuery_DistinctByT() {
 	for _, product := range noduplicates {
 		fmt.Printf("%s %d\n", product.Name, product.Code)
 	}
-
 	// Output:
 	// apple 9
 	// orange 4
@@ -1711,7 +1658,6 @@ func ExampleQuery_ExceptByT() {
 	for _, product := range except {
 		fmt.Printf("%s %d\n", product.Name, product.Code)
 	}
-
 	// Output:
 	// orange 4
 	// lemon 12
@@ -1729,7 +1675,6 @@ func ExampleQuery_FirstWithT() {
 		)
 
 	fmt.Println(first)
-
 	// Output:
 	// 92
 
@@ -1743,7 +1688,6 @@ func ExampleQuery_ForEach() {
 	From(fruits).ForEach(func(fruit interface{}) {
 		fmt.Println(fruit)
 	})
-
 	// Output:
 	// orange
 	// apple
@@ -1759,7 +1703,6 @@ func ExampleQuery_ForEachIndexed() {
 	From(fruits).ForEachIndexed(func(i int, fruit interface{}) {
 		fmt.Printf("%d.%s\n", i, fruit)
 	})
-
 	// Output:
 	// 0.orange
 	// 1.apple
@@ -1775,7 +1718,6 @@ func ExampleQuery_ForEachT() {
 	From(fruits).ForEachT(func(fruit string) {
 		fmt.Println(fruit)
 	})
-
 	// Output:
 	// orange
 	// apple
@@ -1791,7 +1733,6 @@ func ExampleQuery_ForEachIndexedT() {
 	From(fruits).ForEachIndexedT(func(i int, fruit string) {
 		fmt.Printf("%d.%s\n", i, fruit)
 	})
-
 	// Output:
 	// 0.orange
 	// 1.apple
@@ -1832,7 +1773,6 @@ func ExampleQuery_GroupByT() {
 		}
 
 	}
-
 	// Output:
 	// 1
 	//   Whiskers
@@ -1896,7 +1836,6 @@ func ExampleQuery_GroupJoinT() {
 			fmt.Printf("  %s\n", petName)
 		}
 	}
-
 	// Output:
 	// Hedlund, Magnus:
 	//   Daisy
@@ -1936,7 +1875,6 @@ func ExampleQuery_IntersectByT() {
 	for _, p := range duplicates {
 		fmt.Println(p.Name, "", p.Code)
 	}
-
 	// Output:
 	// apple  9
 
@@ -2074,7 +2012,6 @@ func ExampleQuery_OrderByT() {
 	for _, pet := range orderedPets {
 		fmt.Println(pet.Name, "-", pet.Age)
 	}
-
 	// Output:
 	// Whiskers - 1
 	// Boots - 4
@@ -2116,7 +2053,6 @@ func ExampleQuery_SelectIndexedT() {
 	for _, n := range numsInPlace {
 		fmt.Printf("%d: %t\n", n.Key, n.Value)
 	}
-
 	// Output:
 	// Number: In-place?
 	// 5: false
@@ -2173,7 +2109,6 @@ func ExampleQuery_SelectManyByT() {
 	for _, result := range results {
 		fmt.Println(result)
 	}
-
 	// Output:
 	// Owner: Hedlund, Magnus, Pet: Daisy
 	// Owner: Adams, Terry, Pet: Barley
@@ -2225,7 +2160,6 @@ func ExampleQuery_SelectManyT() {
 	for _, result := range results {
 		fmt.Println(result)
 	}
-
 	// Output:
 	// Rank: #1, Word: the, Counts: 4
 	// Rank: #2, Word: quickly, Counts: 3
@@ -2281,7 +2215,6 @@ func ExampleQuery_SelectManyIndexedT() {
 	for _, result := range results {
 		fmt.Println(result)
 	}
-
 	// Output:
 	// File:[1] - file1.log => line: 1 - INFO: 2013/11/05 18:11:01 main.go:44: Special Information
 	// File:[1] - file1.log => line: 2 - WARNING: 2013/11/05 18:11:01 main.go:45: There is something you need to know about
@@ -2338,7 +2271,6 @@ func ExampleQuery_SelectManyByIndexedT() {
 	for _, result := range results {
 		fmt.Println(result)
 	}
-
 	// Output:
 	// Pet: 0 - Daisy, Owner: Hedlund, Magnus
 	// Pet: 1 - Barley, Owner: Adams, Terry
@@ -2426,7 +2358,6 @@ func ExampleQuery_SortT() {
 	for _, pet := range orderedPets {
 		fmt.Println(pet.Name, "-", pet.Age)
 	}
-
 	// Output:
 	// Whiskers - 1
 	// Boots - 4
@@ -2448,7 +2379,6 @@ func ExampleQuery_TakeWhileT() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [apple banana mango]
 }
@@ -2469,7 +2399,6 @@ func ExampleQuery_TakeWhileIndexedT() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [apple passionfruit banana mango orange blueberry]
 }
@@ -2499,7 +2428,6 @@ func ExampleQuery_ToMapByT() {
 	fmt.Println(map1[4])
 	fmt.Println(map1[9])
 	fmt.Println(map1[12])
-
 	// Output:
 	// orange
 	// apple
@@ -2519,7 +2447,6 @@ func ExampleQuery_WhereT() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [passionfruit blueberry strawberry]
 }
@@ -2537,7 +2464,6 @@ func ExampleQuery_WhereIndexedT() {
 		ToSlice(&query)
 
 	fmt.Println(query)
-
 	// Output:
 	// [0 15 40]
 }
@@ -2554,7 +2480,6 @@ func ExampleQuery_ZipT() {
 		)
 
 	fmt.Println(q.Results())
-
 	// Output:
 	// [[1 one] [2 two] [3 three]]
 }


### PR DESCRIPTION
- Fixed a typo in Comparable godoc
- Removed trailing empty new line (\n\n) from example code snippets.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>